### PR TITLE
Clean up arg parsing with argparse

### DIFF
--- a/file_integrity.py
+++ b/file_integrity.py
@@ -3,6 +3,7 @@
 File Integrity Checker - Verify file integrity with checksums and detect unauthorized changes.
 """
 
+import argparse
 import hashlib
 import json
 import os
@@ -20,9 +21,9 @@ def calculate_checksum(file_path: str, algorithm: str = DEFAULT_ALGORITHM) -> st
     """Calculate the checksum of a file using the specified algorithm."""
     if algorithm not in SUPPORTED_ALGORITHMS:
         raise ValueError(f"Unsupported algorithm: {algorithm}. Supported: {SUPPORTED_ALGORITHMS}")
-    
+
     hash_func = hashlib.new(algorithm)
-    
+
     try:
         with open(file_path, "rb") as f:
             for chunk in iter(lambda: f.read(8192), b""):
@@ -40,26 +41,26 @@ def scan_directory(directory: str, algorithm: str = DEFAULT_ALGORITHM, recursive
         "base_directory": os.path.abspath(directory),
         "files": {}
     }
-    
+
     dir_path = Path(directory)
     if not dir_path.exists():
         raise FileNotFoundError(f"Directory does not exist: {directory}")
-    
+
     if not dir_path.is_dir():
         raise NotADirectoryError(f"Path is not a directory: {directory}")
-    
+
     pattern = "**/*" if recursive else "*"
-    
+
     for file_path in dir_path.glob(pattern):
         if file_path.is_file():
             rel_path = str(file_path.relative_to(dir_path))
-            
+
             if file_path.name == MANIFEST_FILENAME:
                 continue
-            
+
             if file_path.name.startswith("."):
                 continue
-            
+
             try:
                 checksum = calculate_checksum(str(file_path), algorithm)
                 manifest["files"][rel_path] = {
@@ -69,7 +70,7 @@ def scan_directory(directory: str, algorithm: str = DEFAULT_ALGORITHM, recursive
                 }
             except (IOError, OSError) as e:
                 print(f"Warning: Could not process {rel_path}: {e}", file=sys.stderr)
-    
+
     return manifest
 
 
@@ -83,7 +84,7 @@ def load_manifest(manifest_path: str) -> dict:
     """Load a manifest from a JSON file."""
     if not os.path.exists(manifest_path):
         raise FileNotFoundError(f"Manifest file not found: {manifest_path}")
-    
+
     with open(manifest_path, "r") as f:
         return json.load(f)
 
@@ -97,37 +98,37 @@ def verify_integrity(directory: str, manifest: dict) -> dict:
         "added": [],
         "errors": []
     }
-    
+
     dir_path = Path(directory)
     recorded_files = set(manifest.get("files", {}).keys())
     current_files = set()
-    
+
     pattern = "**/*"
     for file_path in dir_path.glob(pattern):
         if file_path.is_file():
             rel_path = str(file_path.relative_to(dir_path))
-            
+
             if file_path.name == MANIFEST_FILENAME:
                 continue
-            
+
             if file_path.name.startswith("."):
                 continue
-            
+
             current_files.add(rel_path)
-    
+
     for rel_path in recorded_files:
         file_path = dir_path / rel_path
-        
+
         if not file_path.exists():
             results["deleted"].append(rel_path)
             continue
-        
+
         recorded_data = manifest["files"][rel_path]
         algorithm = manifest.get("algorithm", DEFAULT_ALGORITHM)
-        
+
         try:
             current_checksum = calculate_checksum(str(file_path), algorithm)
-            
+
             if current_checksum == recorded_data["checksum"]:
                 results["verified"].append(rel_path)
             else:
@@ -138,11 +139,11 @@ def verify_integrity(directory: str, manifest: dict) -> dict:
                 })
         except (IOError, OSError) as e:
             results["errors"].append({"path": rel_path, "error": str(e)})
-    
+
     for rel_path in current_files:
         if rel_path not in recorded_files:
             results["added"].append(rel_path)
-    
+
     return results
 
 
@@ -151,44 +152,44 @@ def print_verification_report(results: dict) -> None:
     print("\n" + "=" * 60)
     print("FILE INTEGRITY VERIFICATION REPORT")
     print("=" * 60)
-    
+
     print(f"\nVerified: {len(results['verified'])} files")
     print(f"Modified: {len(results['modified'])} files")
     print(f"Deleted:  {len(results['deleted'])} files")
     print(f"Added:    {len(results['added'])} files")
     print(f"Errors:   {len(results['errors'])} files")
-    
+
     if results["modified"]:
         print("\n--- MODIFIED FILES ---")
         for item in results["modified"]:
             print(f"  [MODIFIED] {item['path']}")
             print(f"    Expected: {item['expected']}")
             print(f"    Actual:   {item['actual']}")
-    
+
     if results["deleted"]:
         print("\n--- DELETED FILES ---")
         for path in results["deleted"]:
             print(f"  [DELETED] {path}")
-    
+
     if results["added"]:
         print("\n--- ADDED FILES ---")
         for path in results["added"]:
             print(f"  [ADDED] {path}")
-    
+
     if results["errors"]:
         print("\n--- ERRORS ---")
         for item in results["errors"]:
             print(f"  [ERROR] {item['path']}: {item['error']}")
-    
+
     print("\n" + "=" * 60)
-    
+
     has_issues = any([
         results["modified"],
         results["deleted"],
         results["added"],
         results["errors"]
     ])
-    
+
     if has_issues:
         print("STATUS: INTEGRITY CHECK FAILED")
         sys.exit(1)
@@ -197,35 +198,15 @@ def print_verification_report(results: dict) -> None:
         sys.exit(0)
 
 
-def create_command(args: list) -> None:
+def create_command(args: argparse.Namespace) -> None:
     """Handle the 'create' command to generate a new manifest."""
-    if len(args) < 1:
-        print("Usage: file_integrity.py create <directory> [--algorithm <algo>] [--output <path>]")
-        sys.exit(1)
-    
-    directory = args[0]
-    algorithm = DEFAULT_ALGORITHM
-    output_path = None
-    
-    i = 1
-    while i < len(args):
-        if args[i] == "--algorithm" and i + 1 < len(args):
-            algorithm = args[i + 1]
-            i += 2
-        elif args[i] == "--output" and i + 1 < len(args):
-            output_path = args[i + 1]
-            i += 2
-        else:
-            i += 1
-    
-    if output_path is None:
-        output_path = os.path.join(directory, MANIFEST_FILENAME)
-    
-    print(f"Scanning directory: {directory}")
-    print(f"Using algorithm: {algorithm}")
-    
+    output_path = args.output if args.output else os.path.join(args.directory, MANIFEST_FILENAME)
+
+    print(f"Scanning directory: {args.directory}")
+    print(f"Using algorithm: {args.algorithm}")
+
     try:
-        manifest = scan_directory(directory, algorithm)
+        manifest = scan_directory(args.directory, args.algorithm)
         save_manifest(manifest, output_path)
         print(f"Manifest saved to: {output_path}")
         print(f"Total files recorded: {len(manifest['files'])}")
@@ -234,32 +215,16 @@ def create_command(args: list) -> None:
         sys.exit(1)
 
 
-def verify_command(args: list) -> None:
+def verify_command(args: argparse.Namespace) -> None:
     """Handle the 'verify' command to check files against a manifest."""
-    if len(args) < 1:
-        print("Usage: file_integrity.py verify <directory> [--manifest <path>]")
-        sys.exit(1)
+    manifest_path = args.manifest if args.manifest else os.path.join(args.directory, MANIFEST_FILENAME)
 
-    directory = args[0]
-    manifest_path = None
-
-    i = 1
-    while i < len(args):
-        if args[i] == "--manifest" and i + 1 < len(args):
-            manifest_path = args[i + 1]
-            i += 2
-        else:
-            i += 1
-
-    if manifest_path is None:
-        manifest_path = os.path.join(directory, MANIFEST_FILENAME)
-
-    print(f"Verifying directory: {directory}")
+    print(f"Verifying directory: {args.directory}")
     print(f"Using manifest: {manifest_path}")
 
     try:
         manifest = load_manifest(manifest_path)
-        results = verify_integrity(directory, manifest)
+        results = verify_integrity(args.directory, manifest)
         print_verification_report(results)
     except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -269,87 +234,85 @@ def verify_command(args: list) -> None:
         sys.exit(1)
 
 
-def hash_command(args: list) -> None:
+def hash_command(args: argparse.Namespace) -> None:
     """Handle the 'hash' command to calculate or verify a single file's hash."""
-    if len(args) < 1:
-        print("Usage: file_integrity.py hash <file> [--algorithm <algo>] [--verify <expected_hash>]")
+    if not os.path.exists(args.file):
+        print(f"Error: File not found: {args.file}", file=sys.stderr)
         sys.exit(1)
 
-    file_path = args[0]
-    algorithm = DEFAULT_ALGORITHM
-    expected_hash = None
-
-    i = 1
-    while i < len(args):
-        if args[i] == "--algorithm" and i + 1 < len(args):
-            algorithm = args[i + 1]
-            i += 2
-        elif args[i] == "--verify" and i + 1 < len(args):
-            expected_hash = args[i + 1].lower()
-            i += 2
-        else:
-            i += 1
-
-    if not os.path.exists(file_path):
-        print(f"Error: File not found: {file_path}", file=sys.stderr)
-        sys.exit(1)
-
-    if not os.path.isfile(file_path):
-        print(f"Error: Not a file: {file_path}", file=sys.stderr)
+    if not os.path.isfile(args.file):
+        print(f"Error: Not a file: {args.file}", file=sys.stderr)
         sys.exit(1)
 
     try:
-        actual_hash = calculate_checksum(file_path, algorithm)
+        actual_hash = calculate_checksum(args.file, args.algorithm)
     except (IOError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
-    if expected_hash is not None:
+    if args.verify is not None:
+        expected_hash = args.verify.lower()
         if actual_hash == expected_hash:
-            print(f"OK: {file_path}")
-            print(f"Algorithm: {algorithm}")
+            print(f"OK: {args.file}")
+            print(f"Algorithm: {args.algorithm}")
             print(f"Hash: {actual_hash}")
             sys.exit(0)
         else:
-            print(f"FAILED: {file_path}")
-            print(f"Algorithm: {algorithm}")
+            print(f"FAILED: {args.file}")
+            print(f"Algorithm: {args.algorithm}")
             print(f"Expected: {expected_hash}")
             print(f"Actual:   {actual_hash}")
             sys.exit(1)
     else:
-        print(f"{actual_hash}  {file_path}")
+        print(f"{actual_hash}  {args.file}")
         sys.exit(0)
 
 
 def main():
     """Main entry point for the file integrity checker."""
-    if len(sys.argv) < 2:
-        print("File Integrity Checker")
-        print("Usage: file_integrity.py <command> [options]")
-        print("\nCommands:")
-        print("  create <directory>   Create a new integrity manifest")
-        print("  verify <directory>   Verify files against existing manifest")
-        print("  hash <file>          Calculate or verify a single file's hash")
-        print("\nOptions:")
-        print("  --algorithm <algo>   Hash algorithm (md5, sha1, sha256, sha512)")
-        print("  --manifest <path>    Path to manifest file (for verify)")
-        print("  --output <path>      Output path for manifest (for create)")
-        print("  --verify <hash>      Expected hash value (for hash command)")
+    parser = argparse.ArgumentParser(
+        prog="file_integrity",
+        description="File Integrity Checker - Verify file integrity with checksums and detect unauthorized changes."
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # Create command
+    create_parser = subparsers.add_parser("create", help="Create a new integrity manifest")
+    create_parser.add_argument("directory", help="Directory to scan")
+    create_parser.add_argument(
+        "--algorithm",
+        choices=SUPPORTED_ALGORITHMS,
+        default=DEFAULT_ALGORITHM,
+        help=f"Hash algorithm (default: {DEFAULT_ALGORITHM})"
+    )
+    create_parser.add_argument("--output", help="Output path for the manifest file")
+    create_parser.set_defaults(func=create_command)
+
+    # Verify command
+    verify_parser = subparsers.add_parser("verify", help="Verify files against existing manifest")
+    verify_parser.add_argument("directory", help="Directory to verify")
+    verify_parser.add_argument("--manifest", help="Path to manifest file")
+    verify_parser.set_defaults(func=verify_command)
+
+    # Hash command
+    hash_parser = subparsers.add_parser("hash", help="Calculate or verify a single file's hash")
+    hash_parser.add_argument("file", help="File to hash")
+    hash_parser.add_argument(
+        "--algorithm",
+        choices=SUPPORTED_ALGORITHMS,
+        default=DEFAULT_ALGORITHM,
+        help=f"Hash algorithm (default: {DEFAULT_ALGORITHM})"
+    )
+    hash_parser.add_argument("--verify", help="Expected hash value to verify against")
+    hash_parser.set_defaults(func=hash_command)
+
+    args = parser.parse_args()
+
+    if args.command is None:
+        parser.print_help()
         sys.exit(0)
 
-    command = sys.argv[1]
-    args = sys.argv[2:]
-
-    if command == "create":
-        create_command(args)
-    elif command == "verify":
-        verify_command(args)
-    elif command == "hash":
-        hash_command(args)
-    else:
-        print(f"Unknown command: {command}")
-        print("Use 'create', 'verify', or 'hash'")
-        sys.exit(1)
+    args.func(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refactored the command-line argument handling to use argparse more consistently across all subcommands. Moved the command-specific logic into separate handler functions and wired them up with `set_defaults(func=...)` so each subcommand has its own dedicated handler. This makes the code easier to follow and extends cleanly if we add more commands later. closes #3