### PR TITLE
Drop unused get_terminal_size import

### DIFF
--- a/file_integrity.py
+++ b/file_integrity.py
@@ -10,7 +10,6 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
-from shutil import get_terminal_size
 
 
 SUPPORTED_ALGORITHMS = ["md5", "sha1", "sha256", "sha512"]


### PR DESCRIPTION
Removed an unused `get_terminal_size` import that was left over from earlier development. The function was never actually called in the codebase, so dropping it cleans up the imports section without affecting functionality. closes #7